### PR TITLE
Fix: Resolve ambiguous user_id in tempo.daily_schedule view

### DIFF
--- a/db/init-postgres.sql
+++ b/db/init-postgres.sql
@@ -149,7 +149,7 @@ ORDER BY due_date ASC;
 
 CREATE OR REPLACE VIEW tempo.daily_schedule AS
 SELECT 
-    user_id,
+    COALESCE(calendar_events.user_id, time_blocks.user_id) AS user_id,
     COALESCE(calendar_events.start_time, time_blocks.start_time) AS start_time,
     COALESCE(calendar_events.end_time, time_blocks.end_time) AS end_time,
     COALESCE(calendar_events.title, time_blocks.title) AS title,
@@ -166,7 +166,7 @@ FULL OUTER JOIN
     (calendar_events.start_time, calendar_events.end_time) OVERLAPS 
     (time_blocks.start_time, time_blocks.end_time)
 ORDER BY 
-    user_id, start_time;
+    COALESCE(calendar_events.user_id, time_blocks.user_id), start_time;
 
 -- Create functions
 CREATE OR REPLACE FUNCTION tempo.update_updated_at()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}


### PR DESCRIPTION
In db/init-postgres.sql, the CREATE VIEW statement for tempo.daily_schedule referenced a 'user_id' column that was present in both joined tables (calendar_events and time_blocks), causing an ambiguity.

This commit resolves the ambiguity by using
COALESCE(calendar_events.user_id, time_blocks.user_id) in both the SELECT list and the ORDER BY clause.